### PR TITLE
refactoring

### DIFF
--- a/src/command/categories/misc.rs
+++ b/src/command/categories/misc.rs
@@ -1,4 +1,4 @@
-use crate::{util, box_str, command::{command::{Argument, Command, CommandAvailability, CommandMetadata, ParsedArgument, force_as}, context::Context, messagebuilder::MessageBuilder, registry::CommandResult}};
+use crate::{box_str, command::{command::{Argument, Command, CommandAvailability, CommandMetadata, ParsedArgument, force_as}, context::Context, messagebuilder::MessageBuilder, registry::CommandResult}};
 use force_as::text;
 use lazy_static::lazy_static;
 use std::sync::Arc;

--- a/src/command/command.rs
+++ b/src/command/command.rs
@@ -37,7 +37,7 @@ pub struct CommandMetadata {
 #[derive(Debug)]
 pub struct ParsedCommand {
     pub args: Vec<ParsedArgument>,
-    pub calling_name: Box<str>
+    pub calling_name: &'static str
 }
 
 pub struct ParsedArgumentResult {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 pub async fn handle_event(assyst: Arc<Assyst>, event: Event) {
     match event {
         Event::MessageCreate(message) => {
-            message_create::handle(assyst.clone(), message).await;
+            message_create::handle(assyst, message).await;
         }
         Event::ShardConnected(d) => {
             println!("Shard {}: READY", d.shard_id);

--- a/src/handlers/message_create.rs
+++ b/src/handlers/message_create.rs
@@ -7,18 +7,13 @@ pub async fn handle(
     message: Box<MessageCreate>
 ) -> () {
    if !should_handle_message(&message).await { return };
-   assyst.handle_command(message.0).await;
+   if let Err(e) = assyst.handle_command(message.0).await {
+       println!("Command execution failed: {:?}", e);
+   }
 }
 
 async fn should_handle_message(
     message: &Box<MessageCreate>
 ) -> bool {
-    if message.author.bot 
-    || message.author.discriminator == "0000"
-    || message.guild_id == None
-    {
-        false
-    } else {
-        true
-    }
+    !message.author.bot && message.author.discriminator != "0000" && message.guild_id.is_some()
 }


### PR DESCRIPTION
- gets rid of some warnings
- removes some unnecessary cloning
- replaces `Box<str>` / `String` with `&str` where possible (eg command registry)
- command lookup is O(1) now and no longer iterates over all commands to find command with matching alias